### PR TITLE
Docker image

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,8 @@ There are 2 possible ways to use MiRA:
 
 * from the command line with the `ymira` command.
 
+* via the Docker images `ferreol/mira` 
+
 Provided you have installed required software (see
 [*Prerequisites*](#prerequisites) below), MiRA software is usable right after
 unpacking the archive or cloning the repository and its sub-modules (see
@@ -141,3 +143,9 @@ executable.  For instance:
     cp bin/ymira "$BINDIR"
     edit "$BINDIR/ymira"
     chmod 755 "$BINDIR/ymira"
+
+
+
+###  MiRA  via Docker
+
+MiRA is available as a Docker image that can be run on any system without any further installation. 

--- a/USAGE.md
+++ b/USAGE.md
@@ -217,6 +217,17 @@ of computation.
   less than `FTOL` between two successive iterations or when the norm of the
   gradient becomes smaller than `GTOL`.
 
+## Using MiRA from the command line via Docker
+
+MiRA is available as a Docker image that can be run without installation.  It can be run from the command line:
+
+    docker run --rm -ti -v FOLDER:/home/yorick ferreol/mira [OPTIONS] INPUT [...] OUTPUT
+
+where `FOLDER` is the local folder containing the `INPUT` files,  `[OPTIONS]` are optional settings, `INPUT [...]` are any number of OIFITS 
+input data files and `OUTPUT` is the name of the output FITS file to save the
+resulting image.  Option `-help` can be used for a short description of all
+options.
+
 
 ## Using MiRA in Yorick interpreter
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM ferreol/yeti:bare
+
+MAINTAINER Ferréol Soulez <ferreol.soulez@univ-lyon1.fr>
+
+RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    apk add --update --no-cache --virtual .build-deps  bash git make wget build-base zip  &&\
+    apk add --update  --no-cache fftw-dev  &&\
+    mkdir -p /opt && cd /opt && \
+    wget https://github.com/emmt/OptimPackLegacy/archive/master.zip && \
+    unzip master.zip && rm master.zip && cd OptimPackLegacy-master/ && \
+    yorick/configure && make && make install && \
+    cd /opt && rm -rf OptimPackLegacy-master && \
+    wget https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.4.1.tar.gz && \
+    tar -xvzf nfft-3.4.1.tar.gz && rm nfft-3.4.1.tar.gz && cd nfft-3.4.1/ && \
+    ./configure --enable-openmp  --enable-all && make && make install && \
+    cd .. && rm -rf  nfft-3.4.1 && \
+    wget https://github.com/emmt/ynfft/archive/master.zip && \
+    unzip master.zip && rm master.zip && cd ynfft-master/ && \
+    ./configure  --cflags='-I/usr/local/include -fopenmp -Ofast -march=native -mfpmath=sse -pedantic -pipe -std=c99' && \
+    make && make install && cd /opt && rm -rf ynfft-master && \
+    git clone https://github.com/ferreolS/MiRA.git && cd MiRA/ && \
+    git submodule init && git submodule update && \
+    git submodule foreach 'git checkout master' && \ 
+    ./configure --bindir=/usr/local/bin && make install && cd /opt && rm -rf MiRA && \
+    apk del .build-deps  && \
+    rm -rf /var/cache/apk/* && rm -rf /usr/local/share/doc
+
+ENTRYPOINT ["ymira"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,12 @@ RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories 
     make && make install && cd /opt && rm -rf ynfft-master && \
     git clone https://github.com/ferreolS/MiRA.git && cd MiRA/ && \
     git submodule init && git submodule update && \
-    git submodule foreach 'git checkout master' && \ 
-    ./configure --bindir=/usr/local/bin && make install && cd /opt && rm -rf MiRA && \
+    git submodule foreach 'git checkout master' && \
+    cd lib/yoifits/ && ./configure  && make && make install && \
+    cd ../ylib && ./configure  && make && make install && \
+    cd ../ipy && ./configure  && make && make install && \
+    cd ../.. && ./configure  && make install && \
     apk del .build-deps  && \
     rm -rf /var/cache/apk/* && rm -rf /usr/local/share/doc
 
-ENTRYPOINT ["ymira"]
+ENTRYPOINT ["/opt/MiRA/bin/ymira"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories 
     unzip master.zip && rm master.zip && cd ynfft-master/ && \
     ./configure  --cflags='-I/usr/local/include -fopenmp -Ofast -march=native -mfpmath=sse -pedantic -pipe -std=c99' && \
     make && make install && cd /opt && rm -rf ynfft-master && \
-    git clone https://github.com/ferreolS/MiRA.git && cd MiRA/ && \
+    git clone https://github.com/emmt/MiRA.git && cd MiRA/ && \
     git submodule init && git submodule update && \
     git submodule foreach 'git checkout master' && \
     cd lib/yoifits/ && ./configure  && make && make install && \


### PR DESCRIPTION
Hi Eric, 
This pull request contains the Dockerfile needed to build the docker image. The best things should be to create your own mira docker image on docker hub and link the automated build to your github account. Then replace in Usage.md and Installation.md ferreol/mira by emmt/mira

Ferréol