### PR TITLE
support plugin option, can be overriden by oimaging FITS keyword

### DIFF
--- a/src/mira2_batch.i
+++ b/src/mira2_batch.i
@@ -448,7 +448,8 @@ func mira_main(argv0, argv)
       opt_error, "option `-oi-imaging` requires exactly 2 positional arguments";
       return;
     }
-    mira_set_defaults, opt, mira_read_input_params(argv(1));
+    /* may load plugin and define opt.plugin_obj */
+    mira_set_defaults, opt, mira_read_input_params(argv(1), plugin=opt.plugin_obj);
   }
 
   if (is_hash(opt.plugin_obj)) {

--- a/src/mira2_image.i
+++ b/src/mira2_image.i
@@ -1034,13 +1034,16 @@ errs2caller, mira_find_fits_hdu;
 /*---------------------------------------------------------------------------*/
 /* READ/WRITE ALGORITHM PARAMATERS */
 
-func mira_read_input_params(src)
-/* DOCUMENT tab = mira_read_input_params(src);
+func mira_read_input_params(src, plugin=)
+/* DOCUMENT tab = mira_read_input_params(src, plugin);
 
       yields a hash table with the input parameters found in FITS extension
       "IMAGE-OI INPUT PARAM".  Argument SRC can be a FITS file name or a FITS
       handle.  The returned table may be empty if no such extension is found or
       if it does not contain any known parameters.
+
+      If keyword plugin is specified, the given plugin is invoked to read its
+      specific keywords.
 
    SEE ALSO: mira_write_input_params.
  */
@@ -1087,6 +1090,7 @@ func mira_read_input_params(src)
       sgtol            = mira_get_fits_real(     fh, "LNS_GTOL"),
       sxtol            = mira_get_fits_real(     fh, "LNS_XTOL"),
       plugin           = mira_get_fits_string(   fh, "PLUGIN", lower=1);
+
     if (! is_void(tab.use_vis2)) {
       h_set, tab, use_vis2 = (tab.use_vis2 ? "all" : "none");
     }
@@ -1104,10 +1108,16 @@ func mira_read_input_params(src)
     if (! is_void(tab.initial)) {
       h_set, tab, initial = mira_read_image(fh, hduname=tab.initial);
     }
-    
+    /* support overriding plugin */
+    plugin_obj=plugin
+
     if (! is_void(tab.plugin)) {
-      h_set, tab, plugin_obj= _mira_load_plugin(tab.plugin);
-      subroutine = tab.plugin_obj.__vops__.read_keywords;
+      plugin_obj= _mira_load_plugin(tab.plugin);
+    }
+    /* Maybe read plug-in specific keywords. */
+    if (is_hash(plugin_obj)) {
+      inform,"Reading plugin keywords";
+      subroutine = plugin_obj.__vops__.read_keywords;
       subroutine, tab, fh;
     }
   }
@@ -1277,12 +1287,12 @@ func mira_write_input_params(dest, master, opt)
   }
 
   /* Maybe add plug-in specific keywords. */
-  plugin_obj =  mira_plugin(master);
+  plugin_obj = mira_plugin(master);
   if (is_hash(plugin_obj)) {
-     inform,"Saving plugin";
-     fits_set, fh, "PLUGIN",  opt.plugin,  "plugin name";
-     subroutine = plugin_obj.__vops__.add_keywords;
-     subroutine, master, fh;
+    inform,"Adding plugin keywords";
+    fits_set, fh, "PLUGIN",  opt.plugin,  "plugin name";
+    subroutine = plugin_obj.__vops__.add_keywords;
+    subroutine, master, fh;
   }
   /* Finish the header and, possibly, close the FITS file. */
   fits_write_header, fh;

--- a/src/mira2_image.i
+++ b/src/mira2_image.i
@@ -1035,14 +1035,14 @@ errs2caller, mira_find_fits_hdu;
 /* READ/WRITE ALGORITHM PARAMATERS */
 
 func mira_read_input_params(src, plugin=)
-/* DOCUMENT tab = mira_read_input_params(src, plugin);
+/* DOCUMENT tab = mira_read_input_params(src, plugin=...);
 
       yields a hash table with the input parameters found in FITS extension
       "IMAGE-OI INPUT PARAM".  Argument SRC can be a FITS file name or a FITS
       handle.  The returned table may be empty if no such extension is found or
       if it does not contain any known parameters.
 
-      If keyword plugin is specified, the given plugin is invoked to read its
+      If keyword PLUGIN is specified, the given plugin is invoked to read its
       specific keywords.
 
    SEE ALSO: mira_write_input_params.
@@ -1108,15 +1108,17 @@ func mira_read_input_params(src, plugin=)
     if (! is_void(tab.initial)) {
       h_set, tab, initial = mira_read_image(fh, hduname=tab.initial);
     }
-    /* support overriding plugin */
-    plugin_obj=plugin
 
     if (! is_void(tab.plugin)) {
-      plugin_obj= _mira_load_plugin(tab.plugin);
+      plugin_obj = _mira_load_plugin(tab.plugin);
+    } else {
+      /* support overriding plugin */
+      plugin_obj = plugin
     }
+    
     /* Maybe read plug-in specific keywords. */
     if (is_hash(plugin_obj)) {
-      inform,"Reading plugin keywords";
+      inform, "Reading plugin keywords";
       subroutine = plugin_obj.__vops__.read_keywords;
       subroutine, tab, fh;
     }
@@ -1289,7 +1291,7 @@ func mira_write_input_params(dest, master, opt)
   /* Maybe add plug-in specific keywords. */
   plugin_obj = mira_plugin(master);
   if (is_hash(plugin_obj)) {
-    inform,"Adding plugin keywords";
+    inform, "Adding plugin keywords";
     fits_set, fh, "PLUGIN",  opt.plugin,  "plugin name";
     subroutine = plugin_obj.__vops__.add_keywords;
     subroutine, master, fh;


### PR DESCRIPTION
It allows having ymira -plugin=... but keywords are read from OIFits file (without PLUGIN) i.e. a mixed solution. In Oimaging, the user is not allowed to define the PLUGIN keyword explicitely.