### PR TITLE
Solves "write cannot handle non-array" error in mira2_solver.i

### DIFF
--- a/src/mira2_solver.i
+++ b/src/mira2_solver.i
@@ -322,7 +322,7 @@ func _mira_optm_observer(iters, evals, rejects, t, x, f, g, gpnorm, alpha, fg)
     h_set, fg, niters = iters;
 }
 
-func _mira_optm_printer(output, iters, evals, rejects, t, x, f, g, gpnorm,
+func _mira_optm_printer(output, iters, evals, rejects, t, x, f, g, gnorm,
                         alpha, fg)
 {
   if (evals == 1) {


### PR DESCRIPTION
solves this error:
ERROR (_mira_optm_printer) write cannot handle non-array, complex, or structure
  LINE: 335  FILE: /Users/michel/local/libexec/yorick/i/mira2_solver.i

There may be other similar errors since there is both variables gnorm and gpnorm around.