### PR TITLE
Update mira2_image.i

### DIFF
--- a/src/mira2_image.i
+++ b/src/mira2_image.i
@@ -1375,6 +1375,11 @@ func mira_write_output_params(dest, misc)
     fits_set, fh, "CHISQ", misc.fdata, "Reduced chi-squared";
   }
 
+  /* GPNORM keyword. */
+  if (! is_void(misc.gpnorm)) {
+    fits_set, fh, "GPNORM", misc.gpnorm, "Euclidean norm of projected gradient";
+  }
+
   /* RGL_WGT keyword. */
   if (! is_void(misc.mu)) {
     fits_set, fh, "RGL_WGT", misc.mu, "Regularization weight";


### PR DESCRIPTION
Just to have also in the header the GPNORM value to better know from the header file if the True convergence is robust or not, It happened many times that the convergence has been set True while GPNORM reached still very high values. I think it can be a useful information to get.